### PR TITLE
Added setuptools installer and entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /.idea/
+__pycache__/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -28,13 +28,30 @@ GOPR0893.mp4 -> GOPR0893_1.mp4
 GP010893.mp4 -> GOPR0893_2.mp4
 GP020893.mp4 -> GOPR0893_3.mp4
 ~~~~
-Usage
------
 
-The script was written in Python (2.7+ and 3.3+). To run:
+Installation
+------------
+The script was written in Python (2.7+ and 3.3+), and can be directly run:
+If you want to install it with pip for easy access, run:
+~~~~
+pip install git+https://github.com/kcha/gopro_renamer#egg=gopro_renamer
+~~~~
 
+To install manually, download the repository and run:
+~~~~
+python setup.py install
+~~~~
+
+If you don't want to install the script to your environment,
+you can also run it directly:
 ~~~~
 python gopro_chapter_renamer.py folder_containing_gopro_videos
+~~~~
+Usage
+-----
+To use the script, run:
+~~~~
+gopro_renamer folder_containing_gopro_videos
 ~~~~
 
 The script will search inside the specified folder for `mp4` files that follow

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+
+setup(
+    name = 'gopro_renamer',
+    author = 'Kevin Ha',
+    version = '3.2',
+    py_modules = ['gopro_chapter_renamer'],
+    entry_points = {
+        'console_scripts': ['gopro_renamer = gopro_chapter_renamer:main']
+    }
+)


### PR DESCRIPTION
With this the script can be installed into the python environment using pip or directly via the setup-script.
It installs the script as an entrypoint `gopro_renamer`, which can be used systemwide (if the python environment is loaded).
`README.md` contains a new section installation.
Changes in `.gitignore` are for installation with `python setup.py develop`.